### PR TITLE
Fix for #11

### DIFF
--- a/src/Core/BenchmarkReportProcessor.cs
+++ b/src/Core/BenchmarkReportProcessor.cs
@@ -44,16 +44,13 @@ public static class BenchmarkReportProcessor
 
         enumerable = PivotColumnEachCollection(enumerable, pivotProperty, statisticColumn);
 
-        enumerable = PivotColumnEachCollection(enumerable, pivotProperty, statisticColumn);
+        string[] joinKeyColumns = [mainColumn, .. otherColumnsToSelect, .. groupByColumns];
+        var joined = JoinCollectionsTogether(enumerable, joinKeyColumns, columnsOrder);
 
-        string[] joinKeyColumnsWithOtherColumns = [mainColumn, .. otherColumnsToSelect, .. groupByColumns];
-        ExpandoObject[] joined = JoinCollectionsTogether(enumerable, joinKeyColumnsWithOtherColumns, columnsOrder).ToArray();
-        
         RemoveMarkdownBoldFromProperties(joined);
 
-        string[] joinKeyColumns = [mainColumn, .. groupByColumns];
-        string[]? spectrumColumns = spectrumStatisticColumn ? columnsOrder : null;
-        IEnumerable<ExpandoObject?> result = Process(joined, groupByColumns, spectrumColumns, columnsOrder, highlightGroups, false);
+        var spectrumColumns = spectrumStatisticColumn ? columnsOrder : null;
+        var result = Process(joined, groupByColumns, spectrumColumns, columnsOrder, highlightGroups, boldEntireRowOfLowestValue: false);
 
         string[] allColumnsByOrder = [mainColumn, .. otherColumnsToSelect, .. groupByColumns, .. columnsOrder];
         result.RemovePropertiesExcept(allColumnsByOrder);

--- a/src/Core/BenchmarkReportProcessor.cs
+++ b/src/Core/BenchmarkReportProcessor.cs
@@ -44,13 +44,16 @@ public static class BenchmarkReportProcessor
 
         enumerable = PivotColumnEachCollection(enumerable, pivotProperty, statisticColumn);
 
-        string[] joinKeyColumns = [mainColumn, .. groupByColumns];
-        var joined = JoinCollectionsTogether(enumerable, joinKeyColumns, columnsOrder);
+        enumerable = PivotColumnEachCollection(enumerable, pivotProperty, statisticColumn);
 
+        string[] joinKeyColumnsWithOtherColumns = [mainColumn, .. otherColumnsToSelect, .. groupByColumns];
+        ExpandoObject[] joined = JoinCollectionsTogether(enumerable, joinKeyColumnsWithOtherColumns, columnsOrder).ToArray();
+        
         RemoveMarkdownBoldFromProperties(joined);
 
-        var spectrumColumns = spectrumStatisticColumn ? columnsOrder : null;
-        var result = Process(joined, groupByColumns, spectrumColumns, columnsOrder, highlightGroups, boldEntireRowOfLowestValue: false);
+        string[] joinKeyColumns = [mainColumn, .. groupByColumns];
+        string[]? spectrumColumns = spectrumStatisticColumn ? columnsOrder : null;
+        IEnumerable<ExpandoObject?> result = Process(joined, groupByColumns, spectrumColumns, columnsOrder, highlightGroups, false);
 
         string[] allColumnsByOrder = [mainColumn, .. otherColumnsToSelect, .. groupByColumns, .. columnsOrder];
         result.RemovePropertiesExcept(allColumnsByOrder);


### PR DESCRIPTION
If JoinReportHtmlOptions.OtherColumnsToSelect are used, rows are generated with every PivotProperty and StatisticColumn combination possible even if the values have no correlation in the initial benchmark data. OtherColumnsToSelect should act as additional group key but without splitting the table. The design of the result table leads to this conclusion. With this fix correct pivot tables are shown.

Build of result tables after this fix.
![image](https://github.com/user-attachments/assets/8d1625c4-85b0-434e-a87d-2216c3a5f17d)
